### PR TITLE
New environment and example scenario

### DIFF
--- a/daml-intro/index.json
+++ b/daml-intro/index.json
@@ -1,0 +1,28 @@
+{
+  "title": "Introduction to daml sdk",
+  "description": "",
+  "difficulty": "Beginner",
+  "time": "30 min",
+  "details": {
+    "steps": [
+      {
+        "title": "Step 1",
+        "text": "step1.md"
+      }
+    ],
+    "intro": {
+      "text": "intro.md"
+    },
+    "finish": {
+      "text": "finish.md"
+    }
+  },
+  "environment": {
+    "uilayout": "terminal",
+    "showide": true,
+    "idePort": 23000
+  },
+  "backend": {
+    "imageid": "daml-sdk-env"
+  }
+}

--- a/daml-intro/intro.md
+++ b/daml-intro/intro.md
@@ -1,0 +1,1 @@
+This is an example scenario of the environment `daml-sdk-env`.

--- a/daml-intro/step1.md
+++ b/daml-intro/step1.md
@@ -1,0 +1,12 @@
+This scenario uses the custom environment `daml-sdk-env`. The environment was built following the [Getting Started](https://docs.daml.com/getting-started/installation.html) guide.
+
+The id of the image is defined in the index.json
+
+```
+"backend": {
+  "imageid": "daml-sdk-env"
+}
+```
+
+Now you can use daml:
+`daml version`{{execute}}

--- a/daml-sdk-env/build/1_installdeps.sh
+++ b/daml-sdk-env/build/1_installdeps.sh
@@ -1,1 +1,0 @@
-apt-get update

--- a/daml-sdk-env/katacoda.yaml
+++ b/daml-sdk-env/katacoda.yaml
@@ -1,1 +1,0 @@
-base : ubuntu

--- a/environments/README.md
+++ b/environments/README.md
@@ -1,0 +1,17 @@
+## Creating Custom Environments on Katacoda
+
+NOTE: This is only available with a Katacoda Subscription.
+
+## Creating a new Environment
+
+1) Create a directory. This will be the name of the environment.
+
+2) Within the directory, create a new directory called build
+
+3) Within the build directory, create a series of bash scripts, prefixed with a number to indicate order. For example:
+
+        1_installpackages.sh
+
+        2_pulldockerimages.sh
+
+        3_pulldemos.sh

--- a/environments/daml-sdk-env/build/1_installprerequisites.sh
+++ b/environments/daml-sdk-env/build/1_installprerequisites.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9
+sudo apt-add-repository 'deb http://repos.azulsystems.com/ubuntu stable main'
+
+sudo apt-get update
+sudo apt install zulu-8

--- a/environments/daml-sdk-env/build/2_installdaml.sh
+++ b/environments/daml-sdk-env/build/2_installdaml.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+curl -sSL https://get.daml.com/ | sh

--- a/environments/daml-sdk-env/build/3_configdaml.sh
+++ b/environments/daml-sdk-env/build/3_configdaml.sh
@@ -1,22 +1,15 @@
 #!/bin/bash
-cat <<EOF > /opt/configure-environment.sh
-#!/bin/bash
 echo "PATH=\$PATH:~/.daml/bin" >> ~/.bashrc
 source ~/.bashrc
 
-# uninstall unnecessary extensions
+# uninstall unnecessary VSCode extensions
 rm -rf /opt/.katacodacode/extensions/redhat.vscode-openshift-connector-0.0.19/;
 rm -rf /tmp/.katacodacode/extensions/redhat.vscode-openshift-connector-0.0.19/;
 
-# install daml extension
+# install daml VSCode extension
 cd /tmp && wget http://assets.joinscrapbook.com/daml/DigitalAssetHoldingsLLC.daml-0.13.55.vsix;
 mv DigitalAssetHoldingsLLC.daml-0.13.55.vsix daml-0.13.55.zip;
 mkdir daml-0.13.55 && unzip daml-0.13.55.zip -d daml-0.13.55;
 mv daml-0.13.55/extension /opt/.katacodacode/extensions/daml-0.13.55;
 rm /tmp/daml-0.13.55.zip;
 rm -Rf /tmp/daml-0.13.55;
-EOF
-
-chmod +x /opt/configure-environment.sh
-/opt/configure-environment.sh
-rm /opt/configure-environment.sh

--- a/environments/daml-sdk-env/build/3_configdaml.sh
+++ b/environments/daml-sdk-env/build/3_configdaml.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+cat <<EOF > /opt/configure-environment.sh
+#!/bin/bash
+echo "PATH=\$PATH:~/.daml/bin" >> ~/.bashrc
+source ~/.bashrc
+
+# uninstall unnecessary extensions
+rm -rf /opt/.katacodacode/extensions/redhat.vscode-openshift-connector-0.0.19/;
+rm -rf /tmp/.katacodacode/extensions/redhat.vscode-openshift-connector-0.0.19/;
+
+# install daml extension
+cd /tmp && wget http://assets.joinscrapbook.com/daml/DigitalAssetHoldingsLLC.daml-0.13.55.vsix;
+mv DigitalAssetHoldingsLLC.daml-0.13.55.vsix daml-0.13.55.zip;
+mkdir daml-0.13.55 && unzip daml-0.13.55.zip -d daml-0.13.55;
+mv daml-0.13.55/extension /opt/.katacodacode/extensions/daml-0.13.55;
+rm /tmp/daml-0.13.55.zip;
+rm -Rf /tmp/daml-0.13.55;
+EOF
+
+chmod +x /opt/configure-environment.sh
+/opt/configure-environment.sh
+rm /opt/configure-environment.sh

--- a/environments/daml-sdk-env/katacoda.yaml
+++ b/environments/daml-sdk-env/katacoda.yaml
@@ -1,0 +1,1 @@
+base: 'ubuntu1604'

--- a/test/index.json
+++ b/test/index.json
@@ -23,7 +23,6 @@
   },
   "environment": {
     "showide": true,
-    "ide" : "echo starting code server", 
     "idePort": 23000,
     "uilayout": "terminal-iframe",
     "showdashboard": true,


### PR DESCRIPTION
This PR contains the changes to environment `daml-sdk-env`. We've included the scripts to install the prerequisites, install daml sdk and to configure it. Also, this new environment is referenced in an example scenario called `daml-intro`.

You can see the build of the environment in the dashboard
https://dashboard.katacoda.com/environments/builds/daml

And after the environment is ready you can test the example scenario with the url:
https://beta.katacoda.com/daml/scenarios/daml-intro