### PR TITLE
Image URLs fix

### DIFF
--- a/getting-started/0_intro.md
+++ b/getting-started/0_intro.md
@@ -6,7 +6,7 @@ This is the first in a series of three tutorials to get you up and running with 
 
 The final application will look something like this:
 
-![Final App](assets/gsg_better.gif)
+![Final App](/daml/scenarios/getting-started/assets/gsg_better.gif)
 
 We do not aim to be comprehensive in all DAML concepts and tools (covered in [Writing DAML](https://docs.daml.com/daml/intro/0_Intro.html)) or in all deployment options (see [Deploying](https://docs.daml.com/deploy/index.html)]). The goal is that by the end of this tutorial, you’ll have a good idea of the following:
 

--- a/getting-started/6_use_app.md
+++ b/getting-started/6_use_app.md
@@ -1,22 +1,21 @@
 You should now see the login page for the social network. For simplicity of this app, there is no password or sign-up required. First enter your name and click Log in.
 
-![Login Screen](assets/create-daml-app-login-screen.png)
+![Login Screen](/daml/scenarios/getting-started/assets/create-daml-app-login-screen.png)
 
 You should see the main screen with two panels. One for the users you are following and one for your followers. Initially these are both empty as you are not following anyone and you don’t have any followers! Go ahead and start following users by typing their usernames in the text box and clicking on the Follow button in the top panel.
 
-![Main Screen](assets/create-daml-app-main-screen-initial-view.png)
+![Main Screen](/daml/scenarios/getting-started/assets/create-daml-app-main-screen-initial-view.png)
 
 You’ll notice that the users you just started following appear in the Following panel. However they do not yet appear in the Network panel. This is either because they have not signed up and are not parties on the ledger or they have not yet started followiong you. This social network is similar to Twitter and Instagram, where by following someone, say Alice, you make yourself visible to her but not vice versa. We will see how we encode this in DAML in the next section.
 
-![Bob Follows Alice](assets/create-daml-app-bob-follows-alice.png)
+![Bob Follows Alice](/daml/scenarios/getting-started/assets/create-daml-app-bob-follows-alice.png)
 
 To make this relationship reciprocal, [open the UI](https://[[HOST_SUBDOMAIN]]-3000-[[KATACODA_HOST]].environments.katacoda.com) in a separate browser tab. (Having separate windows/tabs allows you to see both you and the screen of the user you are following at the same time.) Once you log in as the user you are following - Alice, you’ll notice your name in her network. In fact, Alice can see the entire list of users you are follwing in the Network panel. This is because this list is part of the user data that became visible when you started follwing her.
 
-![Alice Sees Bob](assets/create-daml-app-alice-sees-bob.png)
+![Alice Sees Bob](/daml/scenarios/getting-started/assets/create-daml-app-alice-sees-bob.png)
 
 When Alice starts follwing you, you can see her in your network as well. Just switch to the window where you are logged in as yourself - the network should update automatically.
 
-![Bob Sees Alice](assets/create-daml-app-bob-sees-alice-in-the-network.png)
+![Bob Sees Alice](/daml/scenarios/getting-started/assets/create-daml-app-bob-sees-alice-in-the-network.png)
 
 Play around more with the app at your leisure: create new users and start following more users. Observe when a user becomes visible to others - this will be important to understanding DAML’s privacy model later.
-


### PR DESCRIPTION
Just added '/daml/scenarios/getting-started/assets/' to all image url paths. Necessary if we want to embed scenarios on our website.

CHANGELOG_BEGIN
CHANGELOG_END