### PR TITLE
Add course descriptions and clean up paths

### DIFF
--- a/getting-started-pathway.json
+++ b/getting-started-pathway.json
@@ -3,7 +3,7 @@
   "private": false,
   "courses": [
     {      
-      "external_link": "https://www.daml.com/learn/scenario/getting-started/build-and-run",
+      "external_link": "https://www.daml.com/learn/getting-started/build-and-run",
       "title": "Build and Run a DAML App",
       "description": "Get familiar with the getting started application",
       "course_id": "build-and-run"

--- a/homepage-pathway.json
+++ b/homepage-pathway.json
@@ -5,11 +5,13 @@
         {
         "external_link": "https://www.daml.com/websdk",
         "title": "Web SDK",
+        "description": "A plain environment to use the DAML SDK in.",
         "action": "Start"
         },
         {
         "external_link": "https://www.daml.com/learn/getting-started",
         "title": "Get Started with DAML",
+        "description": "A short series of tutorials to learn the basics about DAML development.",
         "action": "Start"
         }
     ]


### PR DESCRIPTION
I finally have a first version of a daml.com with embedding similar to https://learn.openshift.com/
This is a bit of final tidyup.