### PR TITLE
DAML Projects visible in the IDE

### DIFF
--- a/upgrading/extending-daml-models/1_package_ids.md
+++ b/upgrading/extending-daml-models/1_package_ids.md
@@ -17,7 +17,7 @@ in hindsight, and stay exactly as you defined it.
 
 Let's verify this.
 
-First, open the IDE and **wait for it to load**. After that open the `daml/User.daml`{{open}} file.
+First, open the IDE and **wait for it to load**. After that open the `/create-daml-app/daml/User.daml`{{open}} file.
 This is the familiar `User` module of the Getting Started Guide.
 
 In the terminal build the `create-daml-app` package with

--- a/upgrading/extending-daml-models/1_package_ids.md
+++ b/upgrading/extending-daml-models/1_package_ids.md
@@ -1,6 +1,6 @@
 You've already learned how to extend a DAML model when you added the messaging feature to the mini
 social network of the [Getting Started
-Guide](https://daml.com/learn/getting-started/your-first-feature). 
+Guide](https://daml.com/learn/getting-started/your-first-feature).
 
 There's a catch though with extending a DAML model like this. A [DAML
 archive](https://docs.daml.com/daml/reference/packages.html) is build with the `daml build` command.
@@ -97,7 +97,7 @@ see that it's package ID stayed constant.
 
 In the next step you'll learn how to extend your DAML model by creating a new `forum` package
 depending on the `create-daml-app` package. This way you don't touch the package ID of your already
-deployed packages. 
+deployed packages.
 
 Then, in the second tutorial on upgrading we will change the `create-daml-app` package itself and
 you'll learn how to migrate your data on a live system, without violating any data integrity

--- a/upgrading/extending-daml-models/2_new_package.md
+++ b/upgrading/extending-daml-models/2_new_package.md
@@ -6,7 +6,7 @@ user roles.
 In the terminal, change directory to your home directory and create a new empty DAML project:
 
 ```
-cd
+cd ..
 daml new forum
 cd forum
 ```{{execute T1}}

--- a/upgrading/extending-daml-models/2_new_package.md
+++ b/upgrading/extending-daml-models/2_new_package.md
@@ -11,20 +11,7 @@ daml new forum
 cd forum
 ```{{execute T1}}
 
-Let's now also open the new project in the Visual Studio Code IDE. To do so
-
-1. **Open the IDE tab and wait for it to load**
-2. Navigate to the burger menu ![burger menu](assets/vs-burger-menu.png) in the top left corner and select `File -> Open`
-3. A new dialog will open. First click on the two dots ![two dots](assets/vs-two-dots.png)
-4. Then scroll down until you see the `forum` project and then click on it ![forum project](assets/vs-open-forum.png)
-5. Finally click on the `ok` button to switch to the `forum` project in the IDE ![ok button](assets/vs-ok.png)
-
-The whole process is depicted in the video below.
-
-![open the forum project](assets/change-to-forum-project-ide.gif)
-
-The first thing you need to do is to add the `create-daml-app` to the dependencies in the
-`/forum/daml.yaml`{{open}} file. After, the file will look like this:
+The new project is also visible in the Visual Studio Code IDE. The first thing you need to do is to add the `create-daml-app` to the dependencies in the `/forum/daml.yaml`{{open}} file. After, the file will look like this:
 
 <pre class="file" data-target="clipboard">
 sdk-version: 1.1.1

--- a/upgrading/extending-daml-models/2_new_package.md
+++ b/upgrading/extending-daml-models/2_new_package.md
@@ -59,7 +59,7 @@ Now open a new file `/forum/daml/Forum.daml`{{open}}. The data model for the for
 templates `Post` and `Comment`, where `Post` has a non-consuming choice to add comments. Copy the
 following to the file:
 
-<pre class="file" data-filename="../forum/daml/Forum.daml" data-target="append">
+<pre class="file" data-filename="/forum/daml/Forum.daml" data-target="append">
 module Forum where
 
 import User

--- a/upgrading/extending-daml-models/2_new_package.md
+++ b/upgrading/extending-daml-models/2_new_package.md
@@ -24,7 +24,7 @@ The whole process is depicted in the video below.
 ![open the forum project](assets/change-to-forum-project-ide.gif)
 
 The first thing you need to do is to add the `create-daml-app` to the dependencies in the
-`../forum/daml.yaml`{{open}} file. After, the file will look like this:
+`/forum/daml.yaml`{{open}} file. After, the file will look like this:
 
 <pre class="file" data-target="clipboard">
 sdk-version: 1.1.1
@@ -55,7 +55,7 @@ rm daml/Main.daml
 rm daml/Setup.daml
 ```{{execute T1}}
 
-Now open a new file `../forum/daml/Forum.daml`{{open}}. The data model for the forum consists of two
+Now open a new file `/forum/daml/Forum.daml`{{open}}. The data model for the forum consists of two
 templates `Post` and `Comment`, where `Post` has a non-consuming choice to add comments. Copy the
 following to the file:
 

--- a/upgrading/extending-daml-models/3_uploading.md
+++ b/upgrading/extending-daml-models/3_uploading.md
@@ -29,7 +29,7 @@ INFO: Initialized sandbox version 1.1.1 with ledger-id = e0e24b63-322c-4d72-8774
 In the second terminal change directory to the `forum` project.
 
 ```
-cd forum
+cd daml-projects/forum
 ```{{execute T2}}
 
 To extend your application with the new data model, simply upload the package:

--- a/upgrading/extending-daml-models/index.json
+++ b/upgrading/extending-daml-models/index.json
@@ -20,7 +20,8 @@
       }
     ],
     "intro": {
-      "text": "0_intro.md"
+      "text": "0_intro.md",
+      "courseData": "init_background.sh"
     },
     "finish": {
       "text": "99_finish.md"
@@ -28,7 +29,7 @@
   },
   "environment": {
     "showide": true,
-    "uieditorpath": "/root/create-daml-app",
+    "uieditorpath": "/root/daml-projects",
     "showdashboard": true,
     "dashboards": [{"name": "UI", "port": 3000}],
     "terminals": [

--- a/upgrading/extending-daml-models/init.sh
+++ b/upgrading/extending-daml-models/init.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
 
-rm -rf create-daml-app
-daml new create-daml-app create-daml-app
-cd create-daml-app
+cd daml-projects/create-daml-app

--- a/upgrading/extending-daml-models/init_background.sh
+++ b/upgrading/extending-daml-models/init_background.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+init()
+{
+    cd /tmp
+    ~/.daml/bin/daml new create-daml-app create-daml-app
+    mkdir -p /root/daml-projects
+    mkdir - /root/caml-projects/create-daml-app
+    mv create-daml-app/* /root/daml-projects/create-daml-app/
+}
+
+echo Initialising...
+init
+echo Done!

--- a/upgrading/extending-daml-models/init_background.sh
+++ b/upgrading/extending-daml-models/init_background.sh
@@ -5,7 +5,7 @@ init()
     cd /tmp
     ~/.daml/bin/daml new create-daml-app create-daml-app
     mkdir -p /root/daml-projects
-    mkdir - /root/caml-projects/create-daml-app
+    mkdir - /root/daml-projects/create-daml-app
     mv create-daml-app/* /root/daml-projects/create-daml-app/
 }
 


### PR DESCRIPTION
Added the `daml-projects` folder that contains all DAML projects. We reference it in the uieditorpath to have all daml projects visible in the IDE