### PR TITLE
New ubuntu image and upgrade-ui cleanup

### DIFF
--- a/environments/daml-sdk-env/katacoda.yaml
+++ b/environments/daml-sdk-env/katacoda.yaml
@@ -1,1 +1,1 @@
-base : 'ubuntu1604'
+base : 'ubuntu1804'

--- a/upgrading/upgrade-ui/init_background.sh
+++ b/upgrading/upgrade-ui/init_background.sh
@@ -11,8 +11,4 @@ cd create-daml-app
 sed -i 's+ws://localhost:7575/+wss://[[HOST_SUBDOMAIN]]-7575-[[KATACODA_HOST]].environments.katacoda.com/+g' ui/src/config.ts
 mkdir .daml
 
-# make sure there are enough filewatchers for `yarn start`
-echo "fs.inotify.max_user_watches=524288" >> /etc/sysctl.conf
-sysctl -p
-
 echo done


### PR DESCRIPTION
- Katacoda advised that we update our base environment image to ubuntu1804
- Removed the extra sys config for file watchers size in the upgrade-ui scenario