### PR TITLE
Upgrading scenarios to work with DAML SDK 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,5 @@ When using external DAML projects in the scenario (e.g., via a downloaded `.tar`
 
 # Upgrading the DAML SDK version in the Katacoda environment
 
-When upgrading the DAML SDK version in the Katsacoda environment make sure to go through all the scenarios and update
+When upgrading the DAML SDK version in the Katacoda environment make sure to go through all the scenarios and update
 the code snippets that are used in the scenario with the appropriate version (mainly daml version in `daml.yaml` file)

--- a/README.md
+++ b/README.md
@@ -12,3 +12,15 @@
 
 This repo contains environment definitions and scenarios for using DAML within
 the [Katacoda](https://www.katacoda.com) learning environment.
+
+# Ensuring that DAML projects used in the scenarios are up to date with the latest DAML SDK version
+
+When using external DAML projects in the scenario (e.g., via a downloaded `.tar` file) make sure that `daml.yaml` file references the DAML SDK version used in the Katacoda environment. You can do that by either
+
+- Creating a new project with `daml new` command and moving the project files into the folder
+- By changing the DAML SDK version in the `daml.yaml` file via shell and awk
+
+# Upgrading the DAML SDK version in the Katacoda environment
+
+When upgrading the DAML SDK version in the Katsacoda environment make sure to go through all the scenarios and update
+the code snippets that are used in the scenario with the appropriate version (mainly daml version in `daml.yaml` file)

--- a/fundamental-concepts/choices-role-pattern/init_background.sh
+++ b/fundamental-concepts/choices-role-pattern/init_background.sh
@@ -9,5 +9,9 @@ wget https://katacoda.com/daml/courses/fundamental-concepts/choices-role-pattern
 tar xzf create-daml-app.tar.gz
 cd create-daml-app
 mkdir .daml
+cd /tmp
+sdk_version=$(~/.daml/bin/daml version | awk '/(default SDK version for new projects)/ {print $1}')
+echo "DAML SDK version is" $sdk_version
+sed -i "/sdk-version: /c\sdk-version: $sdk_version" /root/create-daml-app/daml.yaml
 
 echo done

--- a/upgrading/extending-daml-models/2_new_package.md
+++ b/upgrading/extending-daml-models/2_new_package.md
@@ -13,6 +13,7 @@ cd forum
 
 The new project is also visible in the Visual Studio Code IDE. The first thing you need to do is to add the `create-daml-app` to the dependencies in the `/forum/daml.yaml`{{open}} file. After, the file will look like this:
 
+<!-- TODO: automate having the right sdk-version in the snippet-->
 <pre class="file" data-target="clipboard">
 sdk-version: 1.2.0
 name: forum

--- a/upgrading/extending-daml-models/2_new_package.md
+++ b/upgrading/extending-daml-models/2_new_package.md
@@ -14,7 +14,7 @@ cd forum
 The new project is also visible in the Visual Studio Code IDE. The first thing you need to do is to add the `create-daml-app` to the dependencies in the `/forum/daml.yaml`{{open}} file. After, the file will look like this:
 
 <pre class="file" data-target="clipboard">
-sdk-version: 1.1.1
+sdk-version: 1.2.0
 name: forum
 source: daml
 parties:

--- a/upgrading/upgrade-running-applications/1_deploy.md
+++ b/upgrading/upgrade-running-applications/1_deploy.md
@@ -10,7 +10,7 @@ directory. The `forum` package has been extended to contain an initialization sc
 ls
 ```{{execute T1}}
 
-Change directory to `create-daml-app` 
+Change directory to `create-daml-app`
 
 ```
 cd create-daml-app
@@ -36,7 +36,7 @@ No we can start a local sandbox ledger with
 daml sandbox
 ```{{execute T1}}
 
-and deploy the packages **in the second terminal after the sandbox has fully started** with 
+and deploy the packages **in the second terminal after the sandbox has fully started** with
 
 ```
 cd forum
@@ -52,5 +52,5 @@ daml script --dar forum-0.1.0.dar --script-name Init:initialize --ledger-host lo
 ```{{execute T2}}
 
 Nice, your social network is running and users are happily posting and commenting in the forum
-(look at the `../forum/Init.daml`{{open}} module in the forum source code to see what). In the next
+(look at the `../forum/daml/Init.daml`{{open}} module in the forum source code to see what). In the next
 step we'll upgrade the `create-daml-app` package with a new feature.

--- a/upgrading/upgrade-running-applications/2_new_feature.md
+++ b/upgrading/upgrade-running-applications/2_new_feature.md
@@ -9,7 +9,7 @@ and open `daml/User.daml`{{open}} in the IDE tab and wait for it to load. We'll 
 data with a `nickname` field, such that the beginning of the template looks like
 
 <pre class="file" data-target="clipboard">
-template User 
+template User
   with
     username: Party
     following: [Party]
@@ -20,7 +20,7 @@ template User
 Of course you could make a lot more involved changes to the template, but for the sake of the
 presentation we restrict ourself to a simple additional data field. Now open the
 `daml.yaml`{{open}}
-file and increase the version of the package to `0.1.1`. 
+file and increase the version of the package to `0.1.1`.
 
 In the terminal, build the new package with
 
@@ -48,7 +48,7 @@ and edit the `../forum/daml.yaml`{{open}} file to update the `create-daml-app` d
 Your `daml.yaml` file should look like
 
 <pre class="file" data-target="clipboard">
-sdk-version: 1.1.1
+sdk-version: 1.2.0
 name: forum
 source: daml
 parties:
@@ -79,7 +79,7 @@ Now build the new forum package with
 daml build -o forum-0.1.1.dar
 ```{{execute T2}}
 
-and deploy it with 
+and deploy it with
 
 ```
 daml ledger upload-dar forum-0.1.1.dar

--- a/upgrading/upgrade-running-applications/2_new_feature.md
+++ b/upgrading/upgrade-running-applications/2_new_feature.md
@@ -47,6 +47,7 @@ cd ../forum
 and edit the `../forum/daml.yaml`{{open}} file to update the `create-daml-app` dependency to 0.1.1.
 Your `daml.yaml` file should look like
 
+<!-- TODO: automate having the right sdk-version in the snippet-->
 <pre class="file" data-target="clipboard">
 sdk-version: 1.2.0
 name: forum

--- a/upgrading/upgrade-running-applications/3_migrate_contract_deps.md
+++ b/upgrading/upgrade-running-applications/3_migrate_contract_deps.md
@@ -18,7 +18,7 @@ project. Open the
 `../migration/daml.yaml`{{open}} file and change it to
 
 <pre class="file" data-target="clipboard">
-sdk-version: 1.1.1
+sdk-version: 1.2.0
 name: migration
 source: daml
 parties:

--- a/upgrading/upgrade-running-applications/3_migrate_contract_deps.md
+++ b/upgrading/upgrade-running-applications/3_migrate_contract_deps.md
@@ -17,6 +17,7 @@ To write a migration contract, we need to import the two versions of each packag
 project. Open the
 `../migration/daml.yaml`{{open}} file and change it to
 
+<!-- TODO: automate having the right sdk-version in the snippet-->
 <pre class="file" data-target="clipboard">
 sdk-version: 1.2.0
 name: migration

--- a/upgrading/upgrade-running-applications/6_1_navigator.md
+++ b/upgrading/upgrade-running-applications/6_1_navigator.md
@@ -4,9 +4,8 @@ Start the navigator with
 daml navigator server
 ```{{execute T2}}
 
-and open the UI tab where the navigator frontend is running. Login as `Alice` and inspect the
+and [open the UI tab](https://[[HOST_SUBDOMAIN]]-4000-[[KATACODA_HOST]].environments.katacoda.com) where the navigator frontend is running. Login as `Alice` and inspect the
 `contracts` tab, where you find `Alice`s `User` contract.
 
 ![AliceContracts](assets/alice_contracts.png)
 ![AlcieUserContract](assets/alice_user_contract.png)
-


### PR DESCRIPTION
Scenarios that were upgraded are:

- fundamental-concepts/choices-role-pattern
- upgrading/extending-daml-models
- upgrading/upgrade-running-applications

Also added info in the README.md on what needs to be done in order to keep your scenario up to date with the SDK version running on Katacoda as well as what needs to be done after updating the environment itself