### PR TITLE
Added for 'important' attribute for the first button

### DIFF
--- a/assets/styling.css
+++ b/assets/styling.css
@@ -1,4 +1,4 @@
 #course-pathway > section > div > div:nth-child(1) > a {
-    background: #fd7700;
-    border-bottom: #fd7700;
+    background: #fd7700 !important;
+    border-bottom: #fd7700 !important;
 }


### PR DESCRIPTION
There's really a bunch of styling coming from katacoda and WP and this was the easiest way to ensure that the first button is colored differently