### PR TITLE
This replaces yarn with npm

### DIFF
--- a/deploying-daml/daml-on-fabric/daml_build_app.md
+++ b/deploying-daml/daml-on-fabric/daml_build_app.md
@@ -8,5 +8,5 @@ daml build
 Okay so now our backend code is compiled but we also want our frontend to be able to interface with it. We could do this all manually but we also [have several codegen](https://docs.daml.com/tools/codegen.html) options available so in this case we'll have our handy `daml` assistant do this for us.
 
 ```
-daml codegen js .daml/dist/my-app-0.1.0.dar -o daml.js
+daml codegen js .daml/dist/create-daml-app-0.1.0.dar -o daml.js
 ```{{execute T1}}

--- a/deploying-daml/daml-on-fabric/daml_run_ui.md
+++ b/deploying-daml/daml-on-fabric/daml_run_ui.md
@@ -3,12 +3,10 @@ Alright now our entire backend is up and running, participant nodes are particip
 ```
 cd $HOME/my-app/ui
 export REACT_APP_LEDGER_ID=fabric-ledger
-yarn install
-yarn start
+npm install
+npm start
 ```{{execute T4}}
 
 Once the web UI has been compiled and started, you should see `Compiled successfully! You can now view create-daml-app in the browser.` in your terminal. You can then [open the UI tab](https://[[HOST_SUBDOMAIN]]-3000-[[KATACODA_HOST]].environments.katacoda.com) and login as one of the users on the system (ie. `Alice`, `Bob`, or `Charlie`). Try it out, you can even add other users as friends.
 
 If you want to dive in further and understand the guarantees DAML gives you, or learn more about how it works then jump over to our [getting started exercises](https://docs.daml.com/getting-started/index.html) and try running DAML locally. We even have a [Sandbox mode](https://docs.daml.com/tools/sandbox.html) so you don't need to do a full distributed ledger deployment if you just want to play around with DAML.
-
-Note: If you're trying this locally on Windows you will need to set the environment variable as `$env:REACT_APP_LEDGER_ID="participant1"`

--- a/deploying-daml/daml-on-sawtooth/1_first_things_first.md
+++ b/deploying-daml/daml-on-sawtooth/1_first_things_first.md
@@ -29,15 +29,15 @@ Now build the JavaScript bindings for the UI in the second terminal with
 
 ```
 cd create-daml-app
-daml codegen js -o daml.js create-daml-app-0.1.0.dar
+daml codegen js -o ui/daml.js create-daml-app-0.1.0.dar
 ```{{execute T2}}
 
 Change to the `ui` directory and build and run the UI with
 
 ```
 cd ui
-yarn install
-yarn start
+npm install
+npm start
 ```{{execute T2}}
 
 Now [open the UI tab](https://[[HOST_SUBDOMAIN]]-3000-[[KATACODA_HOST]].environments.katacoda.com)

--- a/deploying-daml/daml-on-sawtooth/5_running_the_ui.md
+++ b/deploying-daml/daml-on-sawtooth/5_running_the_ui.md
@@ -5,10 +5,10 @@ allocated. Let's see if we can start the UI!
 cd create-daml-app
 cd ui
 export REACT_APP_LEDGER_ID=test
-yarn start
+npm start
 ```{{execute T4}}
 
-After the Yarn development server has started, you can [open the UI tab](https://[[HOST_SUBDOMAIN]]-3000-[[KATACODA_HOST]].environments.katacoda.com).
+After the development server has started, you can [open the UI tab](https://[[HOST_SUBDOMAIN]]-3000-[[KATACODA_HOST]].environments.katacoda.com).
 
 You should be presented with the login screen of the `create-react-app` application and you can
 login as either `Alice` or `Bob`.

--- a/environments/daml-sdk-env/build/1_installprerequisites.sh
+++ b/environments/daml-sdk-env/build/1_installprerequisites.sh
@@ -7,10 +7,6 @@ echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo s
 wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | sudo apt-key add -
 sudo add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
 
-# Following https://classic.yarnpkg.com/en/docs/install/#debian-stable
-curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-
 # Following https://github.com/nodesource/distributions/blob/master/README.md#deb
 curl -sL https://deb.nodesource.com/setup_13.x | sudo -E bash -
 
@@ -20,4 +16,4 @@ sudo apt-get update -y
 sudo apt-get upgrade -y
 sudo apt-get install -y gcc-4.9
 sudo apt-get upgrade -y libstdc++6
-sudo apt install adoptopenjdk-11-hotspot-jre nodejs yarn
+sudo apt install adoptopenjdk-11-hotspot-jre nodejs

--- a/fundamental-concepts/propose-accept-pattern/4_growing_a_friends_network.md
+++ b/fundamental-concepts/propose-accept-pattern/4_growing_a_friends_network.md
@@ -35,14 +35,14 @@ daml build
 then generate the new JavaScript bindings with
 
 ```
-daml codegen js .daml/dist/create-daml-app-0.1.0.dar -o daml.js
+daml codegen js .daml/dist/create-daml-app-0.1.0.dar -o ui/daml.js
 ```{{execute T1}}
 
 and install them
 
 ```
 cd ui
-yarn install
+npm install
 cd ..
 ```{{execute T1}}
 
@@ -56,5 +56,5 @@ and the new UI in the second terminal
 
 ```
 cd create-daml-app/ui
-yarn start
+npm start
 ```{{execute T2}}

--- a/getting-started/build-and-run/3_build_ui.md
+++ b/getting-started/build-and-run/3_build_ui.md
@@ -2,17 +2,16 @@
 DAML provides a [codegen tool](https://docs.daml.com/app-dev/bindings-ts/daml2js.html) to easily interact with an application on a DAML ledger via the JSON API. To generate this code we run:
 
 ```
-daml codegen js .daml/dist/create-daml-app-0.1.0.dar -o daml.js
+daml codegen js .daml/dist/create-daml-app-0.1.0.dar -o ui/daml.js
 ```{{execute T1}}
 
 > Note: Our UI will later use this code to interact with our DAML application over the JSON API
 
-Now, change to the `ui/` folder use Yarn to install the dependencies for the UI:
+Now, change to the `ui/` folder and use `npm` to install the dependencies for the UI:
 
 ```
 cd ui
-yarn install
+npm install
 ```{{execute T1}}
 
 This step may take a couple of moments. You'll see `success Saved lockfile` in the terminal when it's done.
-

--- a/getting-started/build-and-run/5_start_ui.md
+++ b/getting-started/build-and-run/5_start_ui.md
@@ -1,7 +1,7 @@
 We can now start the UI by running 
 
 ```
-yarn start
+npm start
 ```{{execute T1}}
 
 This starts the web UI which will connect to our JSON API server. 

--- a/getting-started/deploy-to-dabl/3_build_ui.md
+++ b/getting-started/deploy-to-dabl/3_build_ui.md
@@ -5,15 +5,15 @@ The UI package will be the result of the auto-generated javascript objects from 
 Let's first run the code generation step by pointing the codegen tool to the `.dar` we created in the previous step:
 
 ```
-daml codegen js target/create-daml-app.dar -o daml.js
+daml codegen js target/create-daml-app.dar -o ui/daml.js
 ```{{execute T1}}
 
-A successful run of the `codegen js` should have created a set of packages in the `daml.js` directory.
+A successful run of the `codegen js` should have created a set of packages in the `ui/daml.js` directory.
 
-Now onto building our UI code. Let's change directories to `ui` and invoke a `yarn install` followed by a `yarn build`:
+Now onto building our UI code. Let's change directories to `ui` and invoke a `npm install` followed by a `npm run-script build`:
 
 ```
-cd ui && yarn install && yarn build
+cd ui && npm install && npm run-script build
 ```{{execute T1}}
 
 Remember that these steps usually take a couple of moments..

--- a/getting-started/your-first-feature/2_typescript_code_generation.md
+++ b/getting-started/your-first-feature/2_typescript_code_generation.md
@@ -3,16 +3,9 @@ Remember that we interface with the DAML model from the UI components using gene
 ```
 cd create-daml-app
 daml build
-daml codegen js .daml/dist/create-daml-app-0.1.0.dar -o daml.js
+daml codegen js .daml/dist/create-daml-app-0.1.0.dar -o ui/daml.js
 ```{{execute T1}}
 
 The result is an up-to-date TypeScript interface to our DAML model, in particular to the new `Message` template and `SendMessage` choice.
 
-*Only after the above commands have been executed run Yarn to install the project dependencies by clicking on the code below*. To make sure that Yarn picks up the newly generated JavaScript code, we have to run the following command in the ui directory:
-
-```
-cd create-daml-app/ui
-yarn install --force --frozen-lockfile
-```{{execute T2}}
-
-Once that command finishes we can start implementing our messaging feature in the UI!
+Now we can start implementing our messaging feature in the UI!

--- a/getting-started/your-first-feature/7_running_the_new_feature.md
+++ b/getting-started/your-first-feature/7_running_the_new_feature.md
@@ -11,7 +11,7 @@ Wait for the above terminal command to fnish (it is done once you see the `INFO 
 Once the above command has finished, run the below command in terminal 2 by clicking on it.
 
 ```
-yarn start
+npm start
 ```{{execute T2}}
 
 which will start the UI. As a reminder, this starts the web UI connected to the running Sandbox and JSON API server. Once the web UI has been compiled and started, you should see `Compiled successfully!` in your terminal. You can now [open the UI tab](https://[[HOST_SUBDOMAIN]]-3000-[[KATACODA_HOST]].environments.katacoda.com), where you should see the same login page as before

--- a/triggers/writing-triggers/5_running_the_trigger.md
+++ b/triggers/writing-triggers/5_running_the_trigger.md
@@ -9,20 +9,20 @@ There is a small demo UI in the market folder. Get the JavaScript bindings,
 
 ```
 cd market
-daml codegen js -o daml.js .daml/dist/market-0.1.0.dar
+daml codegen js -o ui/daml.js .daml/dist/market-0.1.0.dar
 ```{{execute T2}}
 
 and install the UI dependencies:
 
 ```
 cd ui
-yarn install
+npm install
 ```{{execute T2}}
 
 Finally, start the UI:
 
 ```
-yarn start
+npm start
 ```{{execute T2}}
 
 Triggers are started from the command line with the `daml trigger` command

--- a/upgrading/upgrade-ui/1_codegen.md
+++ b/upgrading/upgrade-ui/1_codegen.md
@@ -13,10 +13,10 @@ In order to do so, you need the generated JavaScript bindings for the newly avai
 so:
 
 ```
-daml codegen js create-daml-app-0.1.0.dar -o daml.js
-daml codegen js create-daml-app-0.1.1.dar -o daml.js
-daml codegen js forum-0.1.0.dar -o daml.js
-daml codegen js migration-0.1.0.dar -o daml.js
+daml codegen js create-daml-app-0.1.0.dar -o ui/daml.js
+daml codegen js create-daml-app-0.1.1.dar -o ui/daml.js
+daml codegen js forum-0.1.0.dar -o ui/daml.js
+daml codegen js migration-0.1.0.dar -o ui/daml.js
 ```{{execute T1}}
 
 Once finished, open `ui/package.json`{{open}} in the IDE and add the new dependencies for the
@@ -24,10 +24,10 @@ Once finished, open `ui/package.json`{{open}} in the IDE and add the new depende
 
 <pre class="file" data-target="clipboard">
   "dependencies": {
-    "@daml.js/create-daml-app-0.1.0": "file:../daml.js/create-daml-app-0.1.0",
-    "@daml.js/create-daml-app": "file:../daml.js/create-daml-app-0.1.1",
-    "@daml.js/forum-0.1.0": "file:../daml.js/forum-0.1.0",
-    "@daml.js/migration-v0-v1": "file:../daml.js/migration-0.1.0",
+    "@daml.js/create-daml-app-0.1.0": "file:daml.js/create-daml-app-0.1.0",
+    "@daml.js/create-daml-app": "file:daml.js/create-daml-app-0.1.1",
+    "@daml.js/forum-0.1.0": "file:daml.js/forum-0.1.0",
+    "@daml.js/migration-v0-v1": "file:daml.js/migration-0.1.0",
     "@daml/ledger": "1.5.0",
     "@daml/react": "1.5.0",
     "@daml/types": "1.5.0",
@@ -44,7 +44,7 @@ and install them with
 
 ```
 cd ui
-yarn install
+npm install
 ```{{execute T1}}
 
 Notice that the `create-daml-app` import now points to the `create-daml-app-0.1.1` package, while we

--- a/upgrading/upgrade-ui/3_demo.md
+++ b/upgrading/upgrade-ui/3_demo.md
@@ -2,7 +2,7 @@ The new UI is ready for a demonstration. Start the UI in the second terminal wit
 
 ```
 cd create-daml-app/ui
-yarn start
+npm start
 ```{{execute T2}}
 
 and [open the UI tab](https://[[HOST_SUBDOMAIN]]-3000-[[KATACODA_HOST]].environments.katacoda.com).


### PR DESCRIPTION
Yarn is removed from the environment and all yarn commands replaced with
npm. Also the codegen directory is now `ui/daml.js`.

CHANGELOG_BEGIN
CHANGELOG_END