### PR TITLE
Typo fix

### DIFF
--- a/upgrading/upgrade-ui/1_codegen.md
+++ b/upgrading/upgrade-ui/1_codegen.md
@@ -24,7 +24,7 @@ Once finished, open `ui/package.json`{{open}} in the IDE and add the new depende
 
 <pre class="file" data-target="clipboard">
   "dependencies": {
-    "@daml.js/create-daml-app-0.1.0": "file:daml.js/create-daml-app-0.1.0",
+    "@daml.js/create-daml-app-0.1.0": "file:./daml.js/create-daml-app-0.1.0",
     "@daml.js/create-daml-app": "file:daml.js/create-daml-app-0.1.1",
     "@daml.js/forum-0.1.0": "file:daml.js/forum-0.1.0",
     "@daml.js/migration-v0-v1": "file:daml.js/migration-0.1.0",


### PR DESCRIPTION
Dunno why but this `"@daml.js/create-daml-app-0.1.0": "file:./daml.js/create-daml-app-0.1.0",` works only if there's a `.` in the path. The rest of the paths work without it