### PR TITLE
Replacing '/learn' with '/interactive-tutorials'

### DIFF
--- a/deploying-daml-pathway.json
+++ b/deploying-daml-pathway.json
@@ -3,13 +3,13 @@
     "private": false,
     "courses": [
       {
-        "external_link": "https://www.daml.com/learn/deploying-daml/daml-on-fabric/",
+        "external_link": "https://www.daml.com/interactive-tutorials/deploying-daml/daml-on-fabric/",
         "title": "Deploy Daml on Fabric",
         "description": "Get familiar with running an application on the Fabric distributed ledger.",
         "course_id": "daml-on-fabric"
       },
       {
-        "external_link": "https://www.daml.com/learn/deploying-daml/daml-on-sawtooth/",
+        "external_link": "https://www.daml.com/interactive-tutorials/deploying-daml/daml-on-sawtooth/",
         "title": "Deploy Daml on Sawtooth",
         "description": "Run your Daml application on the Hyperledger Sawtooth distributed ledger.",
         "course_id": "daml-on-sawtooth"

--- a/deploying-daml/daml-on-sawtooth/1_first_things_first.md
+++ b/deploying-daml/daml-on-sawtooth/1_first_things_first.md
@@ -10,7 +10,7 @@ cd create-daml-app
 
 where you'll find the plain `create-daml-app` template application. If you haven't already, I
 recommend you run through the [Getting Started
-Guide](https://daml.com/learn/getting-started/build-and-run) to get you familiar with the
+Guide](https://daml.com/interactive-tutorials/getting-started/build-and-run) to get you familiar with the
 `create-daml-app` template application.
 
 Compile the application with

--- a/fundamental-concepts-pathway.json
+++ b/fundamental-concepts-pathway.json
@@ -3,37 +3,37 @@
   "private": false,
   "courses": [
     {
-      "external_link": "https://www.daml.com/learn/fundamental-concepts/data-types-imports",
+      "external_link": "https://www.daml.com/interactive-tutorials/fundamental-concepts/data-types-imports",
       "title": "Data types and imports",
       "description": "Learn about functions, records, sums and how to import other packages.",
       "course_id": "data-types-imports"
     },
     {
-      "external_link": "https://www.daml.com/learn/fundamental-concepts/stdlib-tour",
+      "external_link": "https://www.daml.com/interactive-tutorials/fundamental-concepts/stdlib-tour",
       "title": "Explore Daml's standard library",
       "description": "Take a tour through Daml's standard library and learn about lists, maps, sets and optional data types.",
       "course_id": "stdlib-tour"
     },
     {
-      "external_link": "https://www.daml.com/learn/fundamental-concepts/template-authorization",
+      "external_link": "https://www.daml.com/interactive-tutorials/fundamental-concepts/template-authorization",
       "title": "Daml Template Authorization",
       "description": "Understand the 'signatory', 'observer' and 'controller' keywords and learn how you can write secure and privacy respecting Daml applications.",
       "course_id": "template-authorization"
     },
     {
-      "external_link": "https://www.daml.com/learn/fundamental-concepts/choices-role-pattern",
+      "external_link": "https://www.daml.com/interactive-tutorials/fundamental-concepts/choices-role-pattern",
       "title": "Choices and the Role Pattern",
       "description": "Design the API of your application with consuming and non-consuming choices and structure your code with the role pattern.",
       "course_id": "choices-role-pattern"
     },
     {
-      "external_link": "https://www.daml.com/learn/fundamental-concepts/contract-keys",
+      "external_link": "https://www.daml.com/interactive-tutorials/fundamental-concepts/contract-keys",
       "title": "Contract Keys",
       "description": "Keep your API clean and simple with contract keys.",
       "course_id": "contract-keys"
     },
     {
-      "external_link": "https://www.daml.com/learn/fundamental-concepts/propose-accept-pattern",
+      "external_link": "https://www.daml.com/interactive-tutorials/fundamental-concepts/propose-accept-pattern",
       "title": "The Propose/Accept Pattern",
       "description": "Use the Propose/Accept pattern to create multi-signatory contracts and delegate authority.",
       "course_id": "propose-accept-pattern"

--- a/fundamental-concepts/choices-role-pattern/0_intro.md
+++ b/fundamental-concepts/choices-role-pattern/0_intro.md
@@ -10,7 +10,7 @@ will get stored on your chosen back-end ledger, it will expose a gRPC and JSON A
 client side and UI libraries to connect to it, all without you writing a single line of code.
 
 In the [Daml Template
-Authorization](https://daml.com/learn/fundamental-concepts/template-authorization/) tutorial we
+Authorization](https://daml.com/interactive-tutorials/fundamental-concepts/template-authorization/) tutorial we
 discussed how to setup access rights to your application data. In this tutorial you'll learn how to
 design your exposed API to interact with your application with [Daml
 choices](https://docs.daml.com/daml/reference/choices.html).

--- a/fundamental-concepts/choices-role-pattern/3_consuming_choices.md
+++ b/fundamental-concepts/choices-role-pattern/3_consuming_choices.md
@@ -67,7 +67,7 @@ Note that we dropped the `nonconsuming` before the `choice` keyword. This makes 
 `consuming`.
 
 Because the `receivingParty` is the controller of the choice only she can take the offer (check out
-the previous [Katacoda](https://daml.com/learn/fundamental-concepts/template-authorization) for more
+the previous [Katacoda](https://daml.com/interactive-tutorials/fundamental-concepts/template-authorization) for more
 on authorization and controllers). As soon as she takes the offer, the `SpecialOffer` is archived on
 the ledger, marked as inactive and the choice can not be executed any longer.
 

--- a/fundamental-concepts/data-types-imports/2_records.md
+++ b/fundamental-concepts/data-types-imports/2_records.md
@@ -58,7 +58,7 @@ You can think of a contract **template** as a record data type annotated with wh
 **signatories**, what parties are **observing** the contract and what **choices** to build
 transactions are made available by the contract. We will cover these concepts in depth in the
 following Katacoda's of the [fundamental concepts
-course](https://daml.com/learn/fundamental-concepts). For example, we can turn our `Person` data
+course](https://daml.com/interactive-tutorials/fundamental-concepts). For example, we can turn our `Person` data
 type into a simple contract template:
 
 <pre class="file" data-filename="daml/AddressBook.daml" data-target="append">

--- a/fundamental-concepts/data-types-imports/99_finish.md
+++ b/fundamental-concepts/data-types-imports/99_finish.md
@@ -4,8 +4,8 @@ In this scenario you learned how to model data with Daml. You now know
   - structure your code into modules and import them
   - how to import the standard library
 
-In the next Katacoda of the [fundamental concepts](https://daml.com/learn/fundamental-concepts)
-course you will take a tour of [Daml's standard library](https://daml.com/learn/fundamental-concepts/stdlib-tour), where you'll see common container types like
+In the next Katacoda of the [fundamental concepts](https://daml.com/interactive-tutorials/fundamental-concepts)
+course you will take a tour of [Daml's standard library](https://daml.com/interactive-tutorials/fundamental-concepts/stdlib-tour), where you'll see common container types like
 lists, maps, sets and optional data.
 
 Come and connect with the Daml Community on the [Daml forum](https://discuss.daml.com) and share

--- a/fundamental-concepts/propose-accept-pattern/0_intro.md
+++ b/fundamental-concepts/propose-accept-pattern/0_intro.md
@@ -1,4 +1,4 @@
-In [Choices and the Role Pattern](https://daml.com/learn/fundamental-concepts/choices-role-pattern)
+In [Choices and the Role Pattern](https://daml.com/interactive-tutorials/fundamental-concepts/choices-role-pattern)
 you learned about the Role Pattern to group non-consuming choices and define user roles with clearly
 specified capabilities.
 

--- a/fundamental-concepts/propose-accept-pattern/1_making_friends.md
+++ b/fundamental-concepts/propose-accept-pattern/1_making_friends.md
@@ -41,7 +41,7 @@ template User with
 - The `NewFriendRequest` choice simply creates a `FriendRequest` contract. We use the record punning
   syntax `..`, to automatically assign the `friend` field of the choice argument to the `friend`
   field of the `FriendRequest` contract
-- We use [contract keys](https://daml.com/learn/fundamental-concepts/contract-keys) instead of
+- We use [contract keys](https://daml.com/interactive-tutorials/fundamental-concepts/contract-keys) instead of
   contract IDs in the `AcceptFriendRequest` choice to make the code and API simpler.
 
 Let's see how we can implement the `FriendRequest` and `Friendship` contracts to complete the model.

--- a/fundamental-concepts/stdlib-tour/99_finish.md
+++ b/fundamental-concepts/stdlib-tour/99_finish.md
@@ -4,9 +4,9 @@ Congratulations on finishing the tour! You now know
   - map and fold over lists
   - search docs.daml.com for function types
 
-The next Katacoda of the [fundamental concepts](https://daml.com/learn/fundamental-concepts) course
+The next Katacoda of the [fundamental concepts](https://daml.com/interactive-tutorials/fundamental-concepts) course
 will dive into [Daml templates and their authorization and privacy
-rules](https://daml.com/learn/fundamental-concepts/template-authorization).
+rules](https://daml.com/interactive-tutorials/fundamental-concepts/template-authorization).
 
 Come and connect with the Daml Community on the [Daml forum](https://discuss.daml.com) and share
 your insights, questions and suggestions!

--- a/fundamental-concepts/template-authorization/0_intro.md
+++ b/fundamental-concepts/template-authorization/0_intro.md
@@ -6,7 +6,7 @@ as part of your Daml model gives you the peace of mind that your application doe
 loop-holes and your users data is save.
 
 In this scenario we'll have a close look at the Daml code of the [extended Getting Started
-Guide](https://daml.com/learn/getting-started/your-first-feature) and examine the concepts behind
+Guide](https://daml.com/interactive-tutorials/getting-started/your-first-feature) and examine the concepts behind
 
 - **parties**
 - **observers**

--- a/getting-started-pathway.json
+++ b/getting-started-pathway.json
@@ -3,19 +3,19 @@
   "private": false,
   "courses": [
     {
-      "external_link": "https://www.daml.com/learn/getting-started/build-and-run",
+      "external_link": "https://www.daml.com/interactive-tutorials/getting-started/build-and-run",
       "title": "Build and Run a Daml App",
       "description": "Get familiar with the getting started application",
       "course_id": "build-and-run"
     },
     {
-      "external_link": "https://www.daml.com/learn/getting-started/your-first-feature",
+      "external_link": "https://www.daml.com/interactive-tutorials/getting-started/your-first-feature",
       "title": "Add a new feature with UI elements to your Daml app",
       "description": "Get familiar with the process of adding a new full stack feature to your Daml app",
       "course_id": "your-first-feature"
     },
     {
-      "external_link": "https://www.daml.com/learn/getting-started/deploy-to-dabl",
+      "external_link": "https://www.daml.com/interactive-tutorials/getting-started/deploy-to-dabl",
       "title": "Deploy your Daml app to Daml Hub",
       "description": "Package your create-daml-app application artifacts and deploy them to your Daml Hub account",
       "course_id": "deploy-to-dabl"

--- a/getting-started/build-and-run/0_intro.md
+++ b/getting-started/build-and-run/0_intro.md
@@ -1,8 +1,8 @@
 This is the first in a series of four tutorials to get you up and running with full-stack Daml development. We do this through the example of a simple social networking application. The three tutorials cover:
 
 1. How to build and run the application (this tutorial)
-1. How to write a [new feature for the app](https://daml.com/learn/getting-started/your-first-feature/)
-1. How to deploy your app to [Daml Hub](https://www.daml.com/learn/getting-started/deploy-to-dabl/)
+1. How to write a [new feature for the app](https://daml.com/interactive-tutorials/getting-started/your-first-feature/)
+1. How to deploy your app to [Daml Hub](https://www.daml.com/interactive-tutorials/getting-started/deploy-to-dabl/)
 
 You can also read more about the [architecture of this application here](https://docs.daml.com/getting-started/app-architecture.html)
 

--- a/getting-started/build-and-run/99_finish.md
+++ b/getting-started/build-and-run/99_finish.md
@@ -3,8 +3,8 @@ Well done, you have now built and run your first full stack Daml Application.
 If you want to continue learning, head over to the next parts of this course:
 
 1. [Application Architecture](https://docs.daml.com/getting-started/app-architecture.html)
-1. [Your First Feature](https://daml.com/learn/getting-started/your-first-feature/)
-1. Deploying to [Daml Hub](https://www.daml.com/learn/getting-started/deploy-to-dabl/)
+1. [Your First Feature](https://daml.com/interactive-tutorials/getting-started/your-first-feature/)
+1. Deploying to [Daml Hub](https://www.daml.com/interactive-tutorials/getting-started/deploy-to-dabl/)
 
 You can continue to use the [Web SDK](https://www.daml.com/websdk) or head over to the [Installation Instructions](https://docs.daml.com/getting-started/installation.html) to install Daml on your local machine.
 

--- a/getting-started/deploy-to-dabl/0_intro.md
+++ b/getting-started/deploy-to-dabl/0_intro.md
@@ -1,8 +1,8 @@
 This is the last in a series of four tutorials to get you up and running with full-stack Daml development and deployment. We do this through the example of a simple social networking application. The four tutorials cover:
 
-1. How to build and run the application ([Running the app](https://daml.com/learn/getting-started/build-and-run/)).
+1. How to build and run the application ([Running the app](https://daml.com/interactive-tutorials/getting-started/build-and-run/)).
 1. The design of its different components ([Application Architecture](https://docs.daml.com/getting-started/app-architecture.html)).
-1. How to write a new feature for the app ([Your First Feature](https://daml.com/learn/getting-started/your-first-feature/)).
+1. How to write a new feature for the app ([Your First Feature](https://daml.com/interactive-tutorials/getting-started/your-first-feature/)).
 1. How to deploy your app to Daml Hub (this tutorial).
 
 In this tutorial we will learn how to take the social network app deploy it to Daml Hub. We will:

--- a/getting-started/your-first-feature/0_intro.md
+++ b/getting-started/your-first-feature/0_intro.md
@@ -1,9 +1,9 @@
 This is the second to last in a series of four tutorials to get you up and running with full-stack Daml development. We do this through the example of a simple social networking application. The four tutorials cover:
 
-1. How to build and run the application ([Running the app](https://daml.com/learn/getting-started/build-and-run/)).
+1. How to build and run the application ([Running the app](https://daml.com/interactive-tutorials/getting-started/build-and-run/)).
 1. The design of its different components ([Application Architecture](https://docs.daml.com/getting-started/app-architecture.html)).
 1. How to write a new feature for the app (this tutorial).
-1. How to deploy your app to [Daml Hub](https://www.daml.com/learn/getting-started/deploy-to-dabl/)
+1. How to deploy your app to [Daml Hub](https://www.daml.com/interactive-tutorials/getting-started/deploy-to-dabl/)
 
 In this scenario we'll dive into implementing a new feature for our social network app. This will give us a better idea how to develop Daml applications using our template.
 

--- a/getting-started/your-first-feature/99_finish.md
+++ b/getting-started/your-first-feature/99_finish.md
@@ -1,6 +1,6 @@
 You’ve gone through the process of setting up a full-stack Daml app and implementing a useful feature end to end. Have a think about how you might further improve or extend this app. For example, you might have noticed that your list of messages can get out of order. You could add a timestamp to the Message template and sort messages in the MessageList component so your most recent are at the top. Of course there are many more features you could imagine (just think of your favourite social media app).
 
-Next up you can learn how to deploy your app to [Daml Hub](https://www.daml.com/learn/getting-started/deploy-to-dabl/) - a hosted and scalable environment supporting all your app management needs.
+Next up you can learn how to deploy your app to [Daml Hub](https://www.daml.com/interactive-tutorials/getting-started/deploy-to-dabl/) - a hosted and scalable environment supporting all your app management needs.
 
 As always, if you have any questions or problems, connect with the Daml Community on the [Daml
 forum](https://discuss.daml.com).

--- a/homepage-pathway.json
+++ b/homepage-pathway.json
@@ -33,6 +33,12 @@
         "action": "Start"
         },
         {
+        "external_link": "https://www.daml.com/interactive-tutorials/deploying-daml/",
+        "title": "Deploying Daml on Production Ledgers",
+        "description": "Get familiar with running a Daml application on distributed ledgers.",
+        "action": "Start"
+        },
+        {
         "external_link": "https://www.daml.com/websdk",
         "title": "Web SDK",
         "description": "A plain environment to use the Daml SDK in.",

--- a/homepage-pathway.json
+++ b/homepage-pathway.json
@@ -3,39 +3,33 @@
     "private": true,
     "courses": [
         {
-        "external_link": "https://www.daml.com/learn/getting-started",
+        "external_link": "https://www.daml.com/interactive-tutorials/getting-started",
         "title": "Get Started with Daml",
         "description": "A short series of tutorials to learn the basics about Daml development.",
         "action": "Start"
         },
         {
-        "external_link": "https://www.daml.com/learn/fundamental-concepts",
+        "external_link": "https://www.daml.com/interactive-tutorials/fundamental-concepts",
         "title": "Fundamental Daml Concepts",
         "description": "Start modeling your data in Daml, understand the 'signatory', 'observer' and 'controller' keywords and learn how you can write secure and privacy respecting Daml applications.",
         "action": "Start"
         },
         {
-        "external_link": "https://www.daml.com/learn/scripts",
+        "external_link": "https://www.daml.com/interactive-tutorials/scripts",
         "title": "Daml Scripts",
         "description": "Test your Daml models with scripts and interact with any Daml ledger from the command line.",
         "action": "Start"
         },
         {
-        "external_link": "https://www.daml.com/learn/upgrading",
+        "external_link": "https://www.daml.com/interactive-tutorials/upgrading",
         "title": "Upgrading Daml Applications",
         "description": "Learn how to upgrade running Daml aplication and migrate existing data to your new model.",
         "action": "Start"
         },
         {
-        "external_link": "https://www.daml.com/learn/triggers",
+        "external_link": "https://www.daml.com/interactive-tutorials/triggers",
         "title": "Automation with Daml Triggers",
         "description": "Use Daml triggers to automatically execute choices when a specified ledger event occurs.",
-        "action": "Start"
-        },
-        {
-        "external_link": "https://www.daml.com/learn/deploying-daml/",
-        "title": "Deploying Daml on Production Ledgers",
-        "description": "Get familiar with running a Daml application on distributed ledgers.",
         "action": "Start"
         },
         {

--- a/scripts/0_intro.md
+++ b/scripts/0_intro.md
@@ -11,7 +11,7 @@ This tutorial will teach you how to
 1. run Daml scripts against a ledger
 1. start the REPL and interact with a ledger
 
-We'll take the Daml model of the social network of the [Getting Started](https://daml.com/learn/getting-started/)
+We'll take the Daml model of the social network of the [Getting Started](https://daml.com/interactive-tutorials/getting-started/)
 guide and extend it with tests. After that, we'll be 100% certain that we're not sending any
 messages to the wrong person!
 

--- a/triggers-pathway.json
+++ b/triggers-pathway.json
@@ -3,7 +3,7 @@
   "private": false,
   "courses": [
     {
-      "external_link": "https://www.daml.com/learn/triggers/writing-triggers",
+      "external_link": "https://www.daml.com/interactive-tutorials/triggers/writing-triggers",
       "title": "Automation with Daml triggers",
       "description": "Use Daml triggers to automatically execute choices when a specified ledger event occurs.",
       "course_id": "writing-triggers"

--- a/triggers/writing-triggers/2_an_online_market.md
+++ b/triggers/writing-triggers/2_an_online_market.md
@@ -96,7 +96,7 @@ template PaymentConfirmation
         archive self
 </pre>
 
-- Our market model follows the [Role pattern](https://daml.com/learn/fundamental-concepts/choices-role-pattern). It defines a `User` template and offers non-consuming choices to
+- Our market model follows the [Role pattern](https://daml.com/interactive-tutorials/fundamental-concepts/choices-role-pattern). It defines a `User` template and offers non-consuming choices to
   - create a new offer
   - take an offer
   - create a payment confirmation to signal that a payment has been received for the offer

--- a/upgrading-pathway.json
+++ b/upgrading-pathway.json
@@ -3,19 +3,19 @@
   "private": false,
   "courses": [
     {
-      "external_link": "https://www.daml.com/learn/upgrading/extending-daml-models",
+      "external_link": "https://www.daml.com/interactive-tutorials/upgrading/extending-daml-models",
       "title": "Extend Daml Models with Packages",
       "description": "Extend a Daml model with a feature contained in a new package and upload it to a running application.",
       "course_id": "extending-daml-models"
     },
     {
-      "external_link": "https://www.daml.com/learn/upgrading/upgrade-running-applications",
+      "external_link": "https://www.daml.com/interactive-tutorials/upgrading/upgrade-running-applications",
       "title": "Upgrade Daml Models and Migrate a Live Application",
       "description": "Learn how to upgrade a Daml model and migrate a running application.",
       "course_id": "upgrade-running-applications"
     },
     {
-      "external_link": "https://www.daml.com/learn/upgrading/upgrade-ui",
+      "external_link": "https://www.daml.com/interactive-tutorials/upgrading/upgrade-ui",
       "title": "Daml Upgrades: User Interface",
       "description": "Extend your UI to carry out upgrades",
       "course_id": "upgrade-ui"

--- a/upgrading/extending-daml-models/0_intro.md
+++ b/upgrading/extending-daml-models/0_intro.md
@@ -7,7 +7,7 @@ of a running ledger with the public for reading but not writing.
 In this first article on Daml application upgrades you learn how to extend your Daml model and ship this
 extension as a Daml package to a running application. This package will depend on the already deployed
 Daml packages running on the ledger. As a running example, we will extend the social network you build in
-the [Getting Started Guide](https://daml.com/learn/getting-started/) with a forum.
+the [Getting Started Guide](https://daml.com/interactive-tutorials/getting-started/) with a forum.
 
 In the follow up article on Daml upgrades, you will learn how to make changes to an already deployed
 Daml package and how to migrate the data to your new model.

--- a/upgrading/extending-daml-models/1_package_ids.md
+++ b/upgrading/extending-daml-models/1_package_ids.md
@@ -1,6 +1,6 @@
 You've already learned how to extend a Daml model when you added the messaging feature to the mini
 social network of the [Getting Started
-Guide](https://daml.com/learn/getting-started/your-first-feature).
+Guide](https://daml.com/interactive-tutorials/getting-started/your-first-feature).
 
 There's a catch though with extending a Daml model like this. A [Daml
 archive](https://docs.daml.com/daml/reference/packages.html) is build with the `daml build` command.

--- a/upgrading/upgrade-running-applications/0_intro.md
+++ b/upgrading/upgrade-running-applications/0_intro.md
@@ -1,4 +1,4 @@
-In the [previous tutorial](https://daml.com/learn/upgrading/extending-daml-models) you extended the
+In the [previous tutorial](https://daml.com/interactive-tutorials/upgrading/extending-daml-models) you extended the
 social network application of the Getting Started Guide with a new forum feature.
 
 The new `forum` package depends now on the `create-daml-app` package. So what happens if you have

--- a/upgrading/upgrade-ui/0_intro.md
+++ b/upgrading/upgrade-ui/0_intro.md
@@ -1,4 +1,4 @@
-In the [previous tutorial](https://daml.com/learn/upgrading/upgrading-daml-models) you learned how
+In the [previous tutorial](https://daml.com/interactive-tutorials/upgrading/upgrading-daml-models) you learned how
 to write a migration contract that prescribes how to migrate live data of the getting started social
 network to a newer version. However, moving contracts manually with the navigator is tedious and
 would soon become unfeasible for big data sets.


### PR DESCRIPTION
Please wait before approving this PR. It simply replaces `/lear` with `/interactive-tutorials` throughout scenarios and pathways